### PR TITLE
Added Tools and ToolChoice to ChainCallOptions

### DIFF
--- a/chains/llm.go
+++ b/chains/llm.go
@@ -30,7 +30,7 @@ var (
 
 // NewLLMChain creates a new LLMChain with an LLM and a prompt.
 func NewLLMChain(llm llms.Model, prompt prompts.FormatPrompter, opts ...ChainCallOption) *LLMChain {
-	opt := &chainCallOption{}
+	opt := &ChainCallOptions{}
 	for _, o := range opts {
 		o(opt)
 	}
@@ -56,7 +56,7 @@ func (c LLMChain) Call(ctx context.Context, values map[string]any, options ...Ch
 		return nil, err
 	}
 
-	result, err := llms.GenerateFromSinglePrompt(ctx, c.LLM, promptValue.String(), getLLMCallOptions(options...)...)
+	result, err := llms.GenerateFromSinglePrompt(ctx, c.LLM, promptValue.String(), GetLLMCallOptions(options...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/chains/options_test.go
+++ b/chains/options_test.go
@@ -1,0 +1,53 @@
+package chains_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tmc/langchaingo/callbacks"
+	"github.com/tmc/langchaingo/chains"
+	"github.com/tmc/langchaingo/llms"
+)
+
+func Test_ChainCallOptions(t *testing.T) {
+	// Test the default values of ChainCallOptions
+	options := &chains.ChainCallOptions{}
+	assert.Equal(t, "", options.Model)
+	assert.Equal(t, 0, options.MaxTokens)
+	assert.Equal(t, 0.0, options.Temperature)
+	assert.Empty(t, options.StopWords)
+	assert.Nil(t, options.StreamingFunc)
+	assert.Equal(t, 0, options.TopK)
+	assert.Equal(t, 0.0, options.TopP)
+	assert.Equal(t, 0, options.Seed)
+	assert.Equal(t, 0, options.MinLength)
+	assert.Equal(t, 0, options.MaxLength)
+	assert.Empty(t, options.Tools)
+	assert.Nil(t, options.ToolChoice)
+	assert.Nil(t, options.CallbackHandler)
+
+	llmOpts := chains.GetLLMCallOptions()
+	// Only StreamingFunc is set
+	assert.Len(t, llmOpts, 1)
+
+	llmOpts = chains.GetLLMCallOptions(
+		chains.WithModel("gpt-3.5-turbo"),
+		chains.WithMaxTokens(100),
+		chains.WithTemperature(0.7),
+		chains.WithStopWords([]string{"foo", "bar"}),
+		chains.WithTopK(10),
+		chains.WithTopP(0.9),
+		chains.WithSeed(42),
+		chains.WithMinLength(5),
+		chains.WithMaxLength(200),
+		chains.WithTools([]llms.Tool{
+			{
+				Type: "tool1",
+			},
+		}),
+		chains.WithToolChoice("tool1"),
+		chains.WithCallback(callbacks.StreamLogHandler{}),
+	)
+
+	assert.Len(t, llmOpts, 12)
+}


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.


1. Added `WithTools` and `WithToolChoice` options to ChainCallOptions
2. Made `GetLLMCallOptions` public

This allows to create LLM Chain with tools to propagage Function parameters to llm.Options

```go
// NewLLMToolsChain creates a new LLMToolsChain with an LLM and a prompt.
func NewLLMToolsChain(llm llms.Model, prompt prompts.FormatPrompter, opts ...chains.ChainCallOption) *LLMToolsChain
...

func (c *LLMToolsChain) WithTools(tools ...llm.ToolWithParameters) *LLMToolsChain {
	c.Tools = getNameToTool(tools)
	return c
}
```